### PR TITLE
Add deferred key loading, loading helpers for key files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - cargo test --verbose
 
 rust:
-  - 1.34.0  # Oldest supported
+  - 1.33.0  # Oldest supported
   - stable
 
 os:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   constructed with a closure that later provides a secret key based on the
   public key present in a stream.
 - Extend deferred key-loading to `DecryptingReader`.
+- Add helper functions to `PublicKey` and `SecretKey` that read/write keys
+  directly to/from PEM-encoded files.
 
 ### Changed
 - Change MSRV from 1.34 to 1.33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add deferred key-loading function to `Decrypter`, allowing the type to be
   constructed with a closure that later provides a secret key based on the
   public key present in a stream.
+- Extend deferred key-loading to `DecryptingReader`.
 
 ### Changed
 - Change MSRV from 1.34 to 1.33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [master] - Unreleased
+### Changed
+- Change MSRV from 1.34 to 1.33
 
 ## [0.1.0] - July 22, 2019
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [master] - Unreleased
+### Added
+- Add deferred key-loading function to `Decrypter`, allowing the type to be
+  constructed with a closure that later provides a secret key based on the
+  public key present in a stream.
+
 ### Changed
 - Change MSRV from 1.34 to 1.33
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![API](https://docs.rs/saltlick/badge.svg)](https://docs.rs/saltlick)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/saltlick-crypto/saltlick-rs.svg)](http://isitmaintained.com/project/saltlick-crypto/saltlick-rs)
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/saltlick-crypto/saltlick-rs.svg)](http://isitmaintained.com/project/saltlick-crypto/saltlick-rs)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.34+-lightgray.svg)](https://github.com/saltlick-crypto/saltlick-rs#minimum-supported-rust-version-msrv)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.33+-lightgray.svg)](https://github.com/saltlick-crypto/saltlick-rs#minimum-supported-rust-version-msrv)
 
 A library for encrypting and decrypting file streams using libsodium.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.34 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.33 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,3 +76,37 @@ impl Into<io::Error> for SaltlickError {
         io::Error::new(io::ErrorKind::Other, self)
     }
 }
+
+/// Errors when loading keys directly from a file.
+///
+/// Errors possible when keys are loaded directly from files. Note that this is
+/// not part of the normal `SaltlickError` because `std::io::Error` does not
+/// implement `Clone`, `Hash`, or `Eq`.
+#[derive(Debug)]
+pub enum SaltlickKeyIoError {
+    IoError(io::Error),
+    SaltlickError(SaltlickError),
+}
+
+impl Error for SaltlickKeyIoError {}
+
+impl fmt::Display for SaltlickKeyIoError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SaltlickKeyIoError::IoError(e) => write!(f, "key file I/O error: {}", e),
+            SaltlickKeyIoError::SaltlickError(e) => write!(f, "key file parse error: {}", e),
+        }
+    }
+}
+
+impl From<io::Error> for SaltlickKeyIoError {
+    fn from(e: io::Error) -> SaltlickKeyIoError {
+        SaltlickKeyIoError::IoError(e)
+    }
+}
+
+impl From<SaltlickError> for SaltlickKeyIoError {
+    fn from(e: SaltlickError) -> SaltlickKeyIoError {
+        SaltlickKeyIoError::SaltlickError(e)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ use pem::PemError;
 use simple_asn1::{ASN1DecodeErr, ASN1EncodeErr};
 
 /// Saltlick errors
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum SaltlickError {
     BadMagic,
     DecryptionFailure,
@@ -23,6 +23,7 @@ pub enum SaltlickError {
     IncorrectKeyLength,
     InvalidKeyFormat,
     PublicKeyMismatch,
+    SecretKeyNotFound,
     StreamStartFailure,
     UnsupportedKeyAlgorithm,
     UnsupportedVersion,
@@ -44,6 +45,7 @@ impl fmt::Display for SaltlickError {
             IncorrectKeyLength => write!(f, "Key is the incorrect length."),
             InvalidKeyFormat => write!(f, "Key file is invalid, must be PEM encoded ASN.1"),
             PublicKeyMismatch => write!(f, "Provided public key does not match file public key."),
+            SecretKeyNotFound => write!(f, "Unable to find secret key for file."),
             StreamStartFailure => write!(f, "Stream failed to start."),
             UnsupportedKeyAlgorithm => write!(f, "Key algorithm is unknown or unsupported."),
             UnsupportedVersion => write!(f, "Version is unknown or unsupported."),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ mod multibuf;
 mod sync;
 mod version;
 
-pub use self::error::SaltlickError;
+pub use self::error::{SaltlickError, SaltlickKeyIoError};
 pub use self::key::{gen_keypair, PublicKey, SecretKey, PUBLICKEYBYTES, SECRETKEYBYTES};
 pub use self::sync::{DecryptingReader, EncryptingWriter};
 pub use self::version::Version;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -126,6 +126,20 @@ impl<R: Read> DecryptingReader<R> {
         }
     }
 
+    /// Create a new decryption layer over `reader` using `secret_key` and `public_key`.
+    pub fn new_deferred<F>(reader: R, lookup_fn: F) -> DecryptingReader<R>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        DecryptingReader {
+            buffer: vec![0u8; DEFAULT_BLOCK_SIZE * 2],
+            decrypter: Decrypter::new_deferred(lookup_fn),
+            finalized: false,
+            inner: reader,
+            plaintext: MultiBuf::new(),
+        }
+    }
+
     /// Stop reading/decrypting immediately and return the underlying reader.
     pub fn into_inner(self) -> R {
         self.inner


### PR DESCRIPTION
One feature I noticed was missing when working on a CLI for saltlick was the ability to provide a matching secret key for a given public key _after_ starting to read an encrypted stream. This capability is really important for being able to start reading a stream, get the public key it was encrypted with, and then pick which secret key to use to decrypt based on that public key.

I implemented this by adding `new_deferred` functions, which take a closure instead of a public/secret keypair. That closure is called once the public key has been read, and returns a matching secret key if it's available.

There were also a couple other small changes I'm tagging onto here. First, I reduced the MSRV to 1.33 since there wasn't anything preventing us from using that. I also added `to_file`/`from_file` helper functions to the `PublicKey` and `SecretKey` types. It was such a common operation in the CLI implementation that it seemed silly not to add it to the base library.