### PR TITLE
Enforce state-machine return with types

### DIFF
--- a/src/crypter.rs
+++ b/src/crypter.rs
@@ -702,7 +702,7 @@ mod tests {
         let test_data = random_bytes(4, 25000);
         let (public, secret) = key::gen_keypair();
 
-        let mut encrypter = Encrypter::new(public.clone());
+        let mut encrypter = Encrypter::new(public);
         let mut ciphertext = Vec::new();
         ciphertext.extend(encrypter.push(&test_data[..], true).unwrap().iter());
 
@@ -718,7 +718,7 @@ mod tests {
         let test_data = random_bytes(5, 25000);
         let (public, _secret) = key::gen_keypair();
 
-        let mut encrypter = Encrypter::new(public.clone());
+        let mut encrypter = Encrypter::new(public);
         let mut ciphertext = Vec::new();
         ciphertext.extend(encrypter.push(&test_data[..], true).unwrap().iter());
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -243,11 +243,7 @@ mod tests {
         let index = ciphertext.len() - 5;
         ciphertext[index] = ciphertext[index].wrapping_add(1);
 
-        let mut decrypter = DecryptingReader::new(
-            public_key.clone(),
-            secret_key.clone(),
-            Cursor::new(ciphertext),
-        );
+        let mut decrypter = DecryptingReader::new(public_key, secret_key, Cursor::new(ciphertext));
         let mut output = Vec::new();
         assert!(decrypter.read_to_end(&mut output).is_err());
     }
@@ -263,11 +259,7 @@ mod tests {
         // Remove a few bytes from the end
         ciphertext.resize(ciphertext.len() - 5, 0);
 
-        let mut decrypter = DecryptingReader::new(
-            public_key.clone(),
-            secret_key.clone(),
-            Cursor::new(ciphertext),
-        );
+        let mut decrypter = DecryptingReader::new(public_key, secret_key, Cursor::new(ciphertext));
         let mut output = Vec::new();
         assert!(decrypter.read_to_end(&mut output).is_err());
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -241,7 +241,7 @@ mod tests {
 
         // Inject a single bad byte near the end of the stream
         let index = ciphertext.len() - 5;
-        ciphertext[index] = 0;
+        ciphertext[index] = ciphertext[index].wrapping_add(1);
 
         let mut decrypter = DecryptingReader::new(
             public_key.clone(),


### PR DESCRIPTION
This is a change that prevents accidentally not returning a value to `state` after a state-machine turn, leaving it in a `None` state and then panicking. This is accomplished by use of a small helper `State` type - `State` has four variants:

* `Next(state)` - go to `state` immediately
* `Return(value, state)` - return `value` and set the state machine to resume at `state` the next time it is called
* `Error(error)` - return `error` - if the state machine is called again after this it will be 
* `Empty` - temporary state used for mem::replace

Using this type means that the state machine return/loop itself is separate from the state machine logic, and each state machine logic branch _must_ return a `State` type. This avoids errors where no new state is set in a state machine branch.

I also found a fun little bug in one of the unit tests that checks for an invalid encrypted stream. I intentionally corrupted the stream by writing a zero into the stream near the end. However, it is totally possible that the valid encrypted stream could contain a zero at that point, so writing a zero doesn't corrupt the stream. That means the stream is valid and the UT fails. I fixed this by just incrementing the byte by 1 so it always is different.