### PR TITLE
deps: Update bytes from 0.4 to 0.5 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         - cargo test --verbose
 
 rust:
-  - 1.36.0  # Oldest supported
+  - 1.39.0  # Oldest supported
   - stable
 
 os:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directly to/from PEM-encoded files.
 
 ### Changed
-- Change MSRV from 1.34 to 1.36 to address MSRV change in sodiumoxide
+- Change MSRV from 1.34 to 1.39 to address MSRV change in sodiumoxide (>=1.36)
+  and bytes (>=1.39).
 
 ## [0.1.0] - July 22, 2019
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 byteorder = "1.3"
-bytes = "0.4"
+bytes = "0.5"
 lazy_static = "1.0"
 pem = "0.7"
 simple_asn1 = "0.4"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![API](https://docs.rs/saltlick/badge.svg)](https://docs.rs/saltlick)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/saltlick-crypto/saltlick-rs.svg)](http://isitmaintained.com/project/saltlick-crypto/saltlick-rs)
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/saltlick-crypto/saltlick-rs.svg)](http://isitmaintained.com/project/saltlick-crypto/saltlick-rs)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.36+-lightgray.svg)](https://github.com/saltlick-crypto/saltlick-rs#minimum-supported-rust-version-msrv)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.39+-lightgray.svg)](https://github.com/saltlick-crypto/saltlick-rs#minimum-supported-rust-version-msrv)
 
 A library for encrypting and decrypting file streams using libsodium.
 
@@ -13,7 +13,7 @@ Please see the [docs](https://docs.rs/saltlick) for details, usage, and examples
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.36 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.39 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
Implements `MultiBuf::into_vec` to replace `Buf::collect` which has
been removed.

Fixes #6

Also bumps MSRV to 1.39.0+ as that is required by the updated `bytes`.