### PR TITLE
refactor: reduce repeated code in state machine

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum SaltlickError {
     InvalidKeyFormat,
     PublicKeyMismatch,
     SecretKeyNotFound,
+    StateMachineErrored,
     StreamStartFailure,
     UnsupportedKeyAlgorithm,
     UnsupportedVersion,
@@ -43,6 +44,10 @@ impl fmt::Display for SaltlickError {
             InvalidKeyFormat => write!(f, "Key file is invalid, must be PEM encoded ASN.1"),
             PublicKeyMismatch => write!(f, "Provided public key does not match file public key."),
             SecretKeyNotFound => write!(f, "Unable to find secret key for file."),
+            StateMachineErrored => write!(
+                f,
+                "The state machine was called having previously returned an error."
+            ),
             StreamStartFailure => write!(f, "Stream failed to start."),
             UnsupportedKeyAlgorithm => write!(f, "Key algorithm is unknown or unsupported."),
             UnsupportedVersion => write!(f, "Version is unknown or unsupported."),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub mod crypter;
 
 mod error;
 mod key;
+mod state;
 mod sync;
 mod version;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Simple state machine wrapper
+
+#[derive(Debug)]
+pub(crate) enum State<S, R> {
+    Next(S),
+    Return(R, S),
+}
+
+pub(crate) trait StateMachine {
+    type State;
+    type Return;
+    type Error;
+
+    fn take_state(&mut self) -> Self::State;
+    fn put_state(&mut self, state: Self::State);
+}
+
+pub(crate) fn turn<SM, F>(state_machine: &mut SM, mut f: F) -> Result<SM::Return, SM::Error>
+where
+    SM: StateMachine,
+    F: FnMut(SM::State, &mut SM) -> Result<State<SM::State, SM::Return>, SM::Error>,
+{
+    let mut current_state = state_machine.take_state();
+    loop {
+        match f(current_state, state_machine) {
+            Ok(State::Next(next)) => {
+                current_state = next;
+            }
+            Ok(State::Return(value, next)) => {
+                state_machine.put_state(next);
+                return Ok(value);
+            }
+            Err(e) => {
+                // After an error, the state is assumed to be invalid and it
+                // is not put back. It is up to the implementers of
+                // `StateMachine` to decide what to do when the state hasn't
+                // been returned. Panicking or resetting the state machine are
+                // two good options.
+                return Err(e);
+            }
+        }
+    }
+}
+
+pub(crate) fn err<S, R, E>(e: E) -> Result<State<S, R>, E> {
+    Err(e)
+}
+
+pub(crate) fn next<S, R, E>(next_state: S) -> Result<State<S, R>, E> {
+    Ok(State::Next(next_state))
+}
+
+pub(crate) fn ret<S, R, E>(retval: R, next_state: S) -> Result<State<S, R>, E> {
+    Ok(State::Return(retval, next_state))
+}


### PR DESCRIPTION
This replaces repeated boilerplate code around handling taking/putting the state with a wrapper type. This wrapper type moves the state machine itself into a closure, allowing nice things like using `?` to return errors and other early returns. It also makes simple an "Errored" state for the state machine so that calling the state machine after it's already returned an error is no longer a panic.

Other than adding early returns where appropriate, I did not change state machine behavior in this commit. Unfortunately it doesn't look like Github diff is aligning very well, but something to keep in mind while reviewing.