### PR TITLE
testing: improve code coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ lazy_static = "1.0"
 pem = "0.7"
 simple_asn1 = "0.4"
 sodiumoxide = "0.2.3"  # 0.2.3 required for `(push|pull)_to_vec`
+strum = "0.18"
+strum_macros = "0.18"
+thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7"
 rand_xorshift = "0.2"
+tempdir = "0.3"

--- a/src/version.rs
+++ b/src/version.rs
@@ -45,3 +45,26 @@ impl Version {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Version;
+
+    #[test]
+    fn to_u8_test() {
+        let v1 = Version::V1;
+        assert_eq!(1u8, v1.to_u8());
+        assert!(!v1.is_unknown());
+        let unknown = Version::Unknown(0u8);
+        assert_eq!(0u8, unknown.to_u8());
+        assert!(unknown.is_unknown());
+    }
+
+    #[test]
+    fn from_u8_test() {
+        let v1 = 1u8;
+        assert_eq!(Version::V1, Version::from_u8(v1));
+        let unknown = 0u8;
+        assert_eq!(Version::Unknown(0u8), Version::from_u8(unknown));
+    }
+}


### PR DESCRIPTION
This overall improves code coverage through a handful of changes:
  * Increased number of tests to cover specific cases highlighted by tarpaulin
  * Converted to using `thiserror`, which is cheating because it moves the `Display` implementations to a proc-macro, which isn't covered by tarpaulin. But it does make things more declarative, readable, and DRY so I'm calling it a win.
  * Added `strum` to format the enum `Debug` implementations, reducing total lines of code and DRYing that as well.