### PR TITLE
testing: add proptest testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,14 @@ jobs:
 
     - stage: test
       rust: 1.39.0  # Oldest supported
-    - rust: stable
+    - name: "Rust: stable + proptests"
+      rust: stable
+      script:
+        # Proptests take a lot longer to run in debug mode, enough so that the
+        # extra time to build in release mode is worth it.
+        - cargo test --release --features=proptest-tests
+    - name: "Rust: stable + tarpaulin"
+      rust: stable
       addons:
         apt:
           packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ strum_macros = "0.18"
 thiserror = "1.0"
 
 [dev-dependencies]
+proptest = "0.9"
 rand = "0.7"
 rand_xorshift = "0.2"
 tempdir = "0.3"
+
+[features]
+default = []
+proptest-tests = []


### PR DESCRIPTION
Add round-trip testing with proptest for two different cases:

  * Making sure that varying input/output buffer sizes still result in valid encrypt/decrypt cycles
  * Making sure that both the encrypter and decrypter can accept random input data without panicking/crashing (errors are okay).

This is my first major foray into proptest, but it seems to be really useful for testing things like this where there is an easy way to check that the output is valid (a round-trip encryption/decryption test in this case) and various levers that can be adjusted. Because of the amount of data these tests are churning through though, it does take quite a bit longer to run if the tests are compiled in debug mode. I've adjusted CI accordingly to only build the proptests in one stage, and to build that stage in release mode.