### PR TITLE
async: initial commit of saltlick async API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       install:
         - rustup component add rustfmt
       script:
-        - cargo fmt --all -- --check
+        - cargo fmt -- --check
     - name: "clippy-and-warnings"
       env: RUSTFLAGS="-D warnings"
       rust: 1.41.1
@@ -35,7 +35,7 @@ jobs:
       script:
         # Proptests take a lot longer to run in debug mode, enough so that the
         # extra time to build in release mode is worth it.
-        - cargo test --release --features=proptest-tests
+        - cargo test --release --all-features
     - name: "Rust: stable + tarpaulin"
       rust: stable
       addons:
@@ -45,7 +45,7 @@ jobs:
       before_cache: |
         bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
       after_success: |
-        cargo tarpaulin --out Xml
+        cargo tarpaulin --features='io-async' --out Xml
         bash <(curl -s https://codecov.io/bash)
     - os: windows
       rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allow control of inner buffer sizes.
 - Wrappers now exist for all permutations of encrypt/decrypt and `Read`,
   `Write`, and `BufRead`.
+- Add async implementations for `AsyncRead`, `AsyncWrite`, `AsyncBufRead` and
+  `Stream` data sources.
 
 ### Changed
 - `Encrypter` and `Decrypter` now reuses buffers for communicating with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,20 +21,33 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 byteorder = "1.3"
 bytes = "0.5"
+futures = { version = "0.3", optional = true }
 lazy_static = "1.0"
 pem = "0.7"
+pin-project-lite = { version = "0.1", optional = true }
 simple_asn1 = "0.4"
 sodiumoxide = "0.2.3"  # 0.2.3 required for `(push|pull)_to_vec`
 strum = "0.18"
 strum_macros = "0.18"
 thiserror = "1.0"
+tokio = { version = "0.2", optional = true }
 
 [dev-dependencies]
+async-stream = "0.2"
 proptest = "0.9"
 rand = "0.7"
 rand_xorshift = "0.2"
 tempdir = "0.3"
 
+[dev-dependencies.tokio]
+version = "0.2"
+features = ["io-util", "macros", "rt-threaded", "stream"]
+
 [features]
 default = []
+io-async = ["futures", "pin-project-lite", "tokio"]
 proptest-tests = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/async_/bufread.rs
+++ b/src/async_/bufread.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Wrapper types over [`AsyncBufRead`] objects.
+//!
+//! [`AsyncBufRead`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncBufRead.html
+
+use super::commonio;
+use crate::{
+    crypter::{Decrypter, Encrypter},
+    key::{PublicKey, SecretKey},
+};
+use pin_project_lite::pin_project;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncBufRead, AsyncRead};
+
+pin_project! {
+    /// Wraps an underlying reader with decryption using the saltlick format.
+    ///
+    /// Wraps a reader that implements [`AsyncBufRead`] and returns a type that
+    /// also implements [`AsyncBufRead`]. Any data read from the returned type
+    /// will be decrypted with the provided secret key.  The public key is also
+    /// checked to make sure this encrypted data is for the public/secret key
+    /// pair provided.
+    ///
+    /// The underlying reader must reach the end of the stream in order to
+    /// complete decryption successfully, as the libsodium crypto relies on an
+    /// end-of-stream tag to provide guarantees of completeness.
+    ///
+    /// [`AsyncBufRead`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncBufRead.html
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct AsyncSaltlickDecrypter<R> {
+        decrypter: Decrypter,
+        #[pin]
+        inner: R,
+    }
+}
+
+impl<R> AsyncSaltlickDecrypter<R> {
+    /// Create a new decryption layer over `reader` using `secret_key` and `public_key`.
+    pub fn new(
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        reader: R,
+    ) -> AsyncSaltlickDecrypter<R> {
+        AsyncSaltlickDecrypter {
+            decrypter: Decrypter::new(public_key, secret_key),
+            inner: reader,
+        }
+    }
+
+    /// Create a new decryption layer over `reader`, using `lookup_fn` to match
+    /// the stream's `public_key` to its `secret_key`.
+    pub fn new_deferred<F>(reader: R, lookup_fn: F) -> AsyncSaltlickDecrypter<R>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        AsyncSaltlickDecrypter {
+            decrypter: Decrypter::new_deferred(lookup_fn),
+            inner: reader,
+        }
+    }
+
+    /// Stop reading/decrypting immediately and return the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: AsyncBufRead> AsyncRead for AsyncSaltlickDecrypter<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut [u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let this = self.project();
+        commonio::poll_read(this.inner, cx, this.decrypter, output)
+    }
+}
+
+pin_project! {
+    /// Wraps an underlying reader with encryption using the saltlick format.
+    ///
+    /// Wraps a reader that implements [`AsyncBufRead`] and returns a type that
+    /// also implements [`AsyncBufRead`]. Any data read from the returned type
+    /// will be encrypted with the provided public key.
+    ///
+    /// The underlying reader must reach the end of the stream in order to
+    /// complete encryption successfully, as the libsodium crypto relies on an
+    /// end-of-stream tag to provide guarantees of completeness.
+    ///
+    /// [`AsyncBufRead`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncBufRead.html
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct AsyncSaltlickEncrypter<R> {
+        encrypter: Encrypter,
+        #[pin]
+        inner: R,
+    }
+}
+
+impl<R> AsyncSaltlickEncrypter<R> {
+    /// Create a new encryption layer over `reader` using `public_key`.
+    pub fn new(public_key: PublicKey, reader: R) -> AsyncSaltlickEncrypter<R> {
+        AsyncSaltlickEncrypter {
+            encrypter: Encrypter::new(public_key),
+            inner: reader,
+        }
+    }
+
+    /// Set the block size for the underlying encrypter.
+    pub fn set_block_size(&mut self, block_size: usize) {
+        self.encrypter.set_block_size(block_size);
+    }
+
+    /// Stop reading/encrypting immediately and return the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: AsyncBufRead> AsyncRead for AsyncSaltlickEncrypter<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut [u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let this = self.project();
+        commonio::poll_read(this.inner, cx, this.encrypter, output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncSaltlickDecrypter, AsyncSaltlickEncrypter};
+    use crate::key::gen_keypair;
+    use rand::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+    use std::io::Cursor;
+    use tokio::io::{AsyncReadExt, BufReader};
+
+    fn random_bytes(seed: u64, size: usize) -> Box<[u8]> {
+        let mut rng = XorShiftRng::seed_from_u64(seed);
+        let mut bytes = vec![0u8; size];
+        rng.fill_bytes(&mut bytes);
+        bytes.into_boxed_slice()
+    }
+
+    #[tokio::test]
+    async fn round_trip_test() {
+        for size in &[
+            1,
+            10 * 1024,
+            32 * 1024,
+            100 * 1024,
+            200 * 1024,
+            10 * 1024 * 1024,
+        ] {
+            let random_data = random_bytes(0, *size);
+            let reader = Cursor::new(random_data.clone());
+            let (public_key, secret_key) = gen_keypair();
+            let mut encrypter = AsyncSaltlickEncrypter::new(public_key.clone(), reader);
+            encrypter.set_block_size(1024);
+            let mut decrypter =
+                AsyncSaltlickDecrypter::new_deferred(BufReader::new(encrypter), |_| {
+                    Some(secret_key)
+                });
+            let mut output = Vec::new();
+            decrypter.read_to_end(&mut output).await.unwrap();
+            assert_eq!(&random_data[..], &output[..]);
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_value_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let mut encrypter =
+            AsyncSaltlickEncrypter::new(public_key.clone(), Cursor::new(random_data));
+        let mut ciphertext = Vec::new();
+        encrypter.read_to_end(&mut ciphertext).await.unwrap();
+
+        // Inject a single bad byte near the end of the stream
+        let index = ciphertext.len() - 5;
+        ciphertext[index] = ciphertext[index].wrapping_add(1);
+
+        let mut decrypter =
+            AsyncSaltlickDecrypter::new(public_key, secret_key, Cursor::new(ciphertext));
+        let mut output = Vec::new();
+        assert!(decrypter.read_to_end(&mut output).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn incomplete_stream_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let mut encrypter =
+            AsyncSaltlickEncrypter::new(public_key.clone(), Cursor::new(random_data));
+        let mut ciphertext = Vec::new();
+        encrypter.read_to_end(&mut ciphertext).await.unwrap();
+
+        // Remove a few bytes from the end
+        ciphertext.resize(ciphertext.len() - 5, 0);
+
+        let mut decrypter =
+            AsyncSaltlickDecrypter::new(public_key, secret_key, Cursor::new(ciphertext));
+        let mut output = Vec::new();
+        assert!(decrypter.read_to_end(&mut output).await.is_err());
+    }
+
+    #[test]
+    fn into_inner_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let encrypter =
+            AsyncSaltlickEncrypter::new(public_key.clone(), Cursor::new(&random_data[..]));
+        let decrypter = AsyncSaltlickDecrypter::new(public_key, secret_key, encrypter);
+        let encrypter = decrypter.into_inner();
+        let recovered_data = encrypter.into_inner().into_inner();
+        assert_eq!(&random_data[..], recovered_data,);
+    }
+}

--- a/src/async_/commonio.rs
+++ b/src/async_/commonio.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::commonio::CommonOps;
+use futures::ready;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncBufRead, AsyncWrite};
+
+pub(crate) fn poll_read<R, Ops>(
+    mut reader: Pin<&mut R>,
+    cx: &mut Context<'_>,
+    ops: &mut Ops,
+    output: &mut [u8],
+) -> Poll<io::Result<usize>>
+where
+    R: AsyncBufRead,
+    Ops: CommonOps,
+{
+    let mut nwritten = 0;
+    loop {
+        if ops.is_finalized() || nwritten >= output.len() {
+            return Poll::Ready(Ok(nwritten));
+        }
+
+        let eof;
+        let (rd, wr) = {
+            let input = ready!(reader.as_mut().poll_fill_buf(cx))?;
+            eof = input.is_empty();
+            ops.run(input, &mut output[nwritten..])?
+        };
+        reader.as_mut().consume(rd);
+        nwritten += wr;
+
+        if wr == 0 {
+            if eof && !ops.is_finalized() {
+                nwritten += ops.finalize(&mut output[nwritten..])?;
+            } else {
+                continue;
+            }
+        } else {
+            return Poll::Ready(Ok(nwritten));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct AsyncBuffer {
+    available: usize,
+    buffer: Box<[u8]>,
+    consumed: usize,
+}
+
+impl AsyncBuffer {
+    pub fn new(capacity: usize) -> AsyncBuffer {
+        AsyncBuffer {
+            available: 0,
+            buffer: vec![0u8; capacity].into_boxed_slice(),
+            consumed: 0,
+        }
+    }
+
+    pub fn poll_flush<W: AsyncWrite>(
+        &mut self,
+        mut writer: Pin<&mut W>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        while self.available - self.consumed > 0 {
+            let n = ready!(writer
+                .as_mut()
+                .poll_write(cx, &self.buffer[self.consumed..self.available]))?;
+            if n == 0 {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write the buffered data",
+                )));
+            } else {
+                self.consumed += n;
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+pub(crate) fn poll_write<W, Ops>(
+    mut writer: Pin<&mut W>,
+    cx: &mut Context<'_>,
+    ops: &mut Ops,
+    buffer: &mut AsyncBuffer,
+    input: &[u8],
+) -> Poll<io::Result<usize>>
+where
+    W: AsyncWrite,
+    Ops: CommonOps,
+{
+    if input.is_empty() {
+        return Poll::Ready(Ok(0));
+    }
+
+    // All buffered content needs to be flushed before writing because we give
+    // the whole buffer to the crypter.
+    ready!(buffer.poll_flush(writer.as_mut(), cx))?;
+
+    loop {
+        let (rd, wr) = ops.run(input, &mut buffer.buffer)?;
+        buffer.available = wr;
+        buffer.consumed = 0;
+        if rd > 0 {
+            return Poll::Ready(Ok(rd));
+        } else {
+            ready!(buffer.poll_flush(writer.as_mut(), cx))?;
+        }
+    }
+}
+
+pub(crate) fn poll_flush<W>(
+    mut writer: Pin<&mut W>,
+    cx: &mut Context<'_>,
+    buffer: &mut AsyncBuffer,
+) -> Poll<io::Result<()>>
+where
+    W: AsyncWrite,
+{
+    ready!(buffer.poll_flush(writer.as_mut(), cx))?;
+    writer.poll_flush(cx)
+}
+
+pub(crate) fn poll_shutdown<W, Ops>(
+    mut writer: Pin<&mut W>,
+    cx: &mut Context<'_>,
+    ops: &mut Ops,
+    buffer: &mut AsyncBuffer,
+) -> Poll<io::Result<()>>
+where
+    W: AsyncWrite,
+    Ops: CommonOps,
+{
+    ready!(buffer.poll_flush(writer.as_mut(), cx))?;
+    loop {
+        let (_, wr) = ops.run(&[], &mut buffer.buffer)?;
+        buffer.available = wr;
+        buffer.consumed = 0;
+        ready!(buffer.poll_flush(writer.as_mut(), cx))?;
+        if wr == 0 {
+            break;
+        }
+    }
+    loop {
+        let wr = ops.finalize(&mut buffer.buffer)?;
+        buffer.available = wr;
+        buffer.consumed = 0;
+        ready!(buffer.poll_flush(writer.as_mut(), cx))?;
+        if wr == 0 {
+            break;
+        }
+    }
+    ready!(writer.poll_shutdown(cx))?;
+    Poll::Ready(Ok(()))
+}

--- a/src/async_/mod.rs
+++ b/src/async_/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub(crate) mod bufread;
+pub(crate) mod read;
+pub(crate) mod write;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+pub mod stream;
+
+mod commonio;

--- a/src/async_/read.rs
+++ b/src/async_/read.rs
@@ -1,0 +1,263 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Wrapper types over [`AsyncRead`] objects.
+//!
+//! [`AsyncRead`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncRead.html
+
+use super::bufread;
+use crate::{
+    crypter::DEFAULT_BLOCK_SIZE,
+    key::{PublicKey, SecretKey},
+};
+use pin_project_lite::pin_project;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncRead, BufReader};
+
+pin_project! {
+    /// Wraps an underlying reader with decryption using the saltlick format.
+    ///
+    /// Wraps a reader that implements [`AsyncRead`] and returns a type that
+    /// also implements [`AsyncRead`]. Any data read from the returned type
+    /// will be decrypted with the provided secret key.  The public key is also
+    /// checked to make sure this encrypted data is for the public/secret key
+    /// pair provided.
+    ///
+    /// The underlying reader must reach the end of the stream in order to
+    /// complete decryption successfully, as the libsodium crypto relies on an
+    /// end-of-stream tag to provide guarantees of completeness.
+    ///
+    /// [`AsyncRead`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncRead.html
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct AsyncSaltlickDecrypter<R> {
+        #[pin]
+        inner: bufread::AsyncSaltlickDecrypter<BufReader<R>>,
+    }
+}
+
+impl<R: AsyncRead> AsyncSaltlickDecrypter<R> {
+    /// Create a new decryption layer over `reader` using `secret_key` and `public_key`.
+    pub fn new(
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        reader: R,
+    ) -> AsyncSaltlickDecrypter<R> {
+        Self::with_capacity(DEFAULT_BLOCK_SIZE, public_key, secret_key, reader)
+    }
+
+    /// Create a new decryption layer over `reader`, using `lookup_fn` to match
+    /// the stream's `public_key` to its `secret_key`.
+    pub fn new_deferred<F>(reader: R, lookup_fn: F) -> AsyncSaltlickDecrypter<R>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        Self::deferred_with_capacity(DEFAULT_BLOCK_SIZE, reader, lookup_fn)
+    }
+
+    /// Create a new decryption layer over `reader` using `secret_key` and
+    /// `public_key` with the specified buffer capacity.
+    pub fn with_capacity(
+        capacity: usize,
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        reader: R,
+    ) -> AsyncSaltlickDecrypter<R> {
+        let bufreader = BufReader::with_capacity(capacity, reader);
+        AsyncSaltlickDecrypter {
+            inner: bufread::AsyncSaltlickDecrypter::new(public_key, secret_key, bufreader),
+        }
+    }
+
+    /// Create a new decryption layer over `reader`, using `lookup_fn` to match
+    /// the stream's `public_key` to its `secret_key` with the specified buffer
+    /// capacity.
+    pub fn deferred_with_capacity<F>(
+        capacity: usize,
+        reader: R,
+        lookup_fn: F,
+    ) -> AsyncSaltlickDecrypter<R>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        let bufreader = BufReader::with_capacity(capacity, reader);
+        AsyncSaltlickDecrypter {
+            inner: bufread::AsyncSaltlickDecrypter::new_deferred(bufreader, lookup_fn),
+        }
+    }
+
+    /// Stop reading/decrypting immediately and return the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
+}
+
+impl<R: AsyncRead> AsyncRead for AsyncSaltlickDecrypter<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_read(cx, output)
+    }
+}
+
+pin_project! {
+    /// Wraps an underlying reader with encryption using the saltlick format.
+    ///
+    /// Wraps a reader that implements [`AsyncRead`] and returns a type that
+    /// also implements [`AsyncRead`]. Any data read from the returned type
+    /// will be encrypted with the provided public key.
+    ///
+    /// The underlying reader must reach the end of the stream in order to
+    /// complete encryption successfully, as the libsodium crypto relies on an
+    /// end-of-stream tag to provide guarantees of completeness.
+    ///
+    /// [`AsyncRead`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncRead.html
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct AsyncSaltlickEncrypter<R> {
+        #[pin]
+        inner: bufread::AsyncSaltlickEncrypter<BufReader<R>>,
+    }
+}
+
+impl<R: AsyncRead> AsyncSaltlickEncrypter<R> {
+    /// Create a new encryption layer over `reader` using `public_key`.
+    pub fn new(public_key: PublicKey, reader: R) -> AsyncSaltlickEncrypter<R> {
+        Self::with_capacity(DEFAULT_BLOCK_SIZE, public_key, reader)
+    }
+
+    /// Create a new encryption layer over `reader` using `secret_key` and
+    /// `public_key` with the specified buffer capacity.
+    pub fn with_capacity(
+        capacity: usize,
+        public_key: PublicKey,
+        reader: R,
+    ) -> AsyncSaltlickEncrypter<R> {
+        let bufreader = BufReader::with_capacity(capacity, reader);
+        AsyncSaltlickEncrypter {
+            inner: bufread::AsyncSaltlickEncrypter::new(public_key, bufreader),
+        }
+    }
+
+    /// Set the block size for the underlying encrypter.
+    pub fn set_block_size(&mut self, block_size: usize) {
+        self.inner.set_block_size(block_size);
+    }
+
+    /// Stop reading/encrypting immediately and return the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
+}
+
+impl<R: AsyncRead> AsyncRead for AsyncSaltlickEncrypter<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_read(cx, output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncSaltlickDecrypter, AsyncSaltlickEncrypter};
+    use crate::key::gen_keypair;
+    use rand::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+    use std::io::Cursor;
+    use tokio::io::{AsyncReadExt, BufReader};
+
+    fn random_bytes(seed: u64, size: usize) -> Box<[u8]> {
+        let mut rng = XorShiftRng::seed_from_u64(seed);
+        let mut bytes = vec![0u8; size];
+        rng.fill_bytes(&mut bytes);
+        bytes.into_boxed_slice()
+    }
+
+    #[tokio::test]
+    async fn round_trip_test() {
+        for size in &[
+            1,
+            10 * 1024,
+            32 * 1024,
+            100 * 1024,
+            200 * 1024,
+            10 * 1024 * 1024,
+        ] {
+            let random_data = random_bytes(0, *size);
+            let reader = Cursor::new(random_data.clone());
+            let (public_key, secret_key) = gen_keypair();
+            let mut encrypter = AsyncSaltlickEncrypter::new(public_key.clone(), reader);
+            encrypter.set_block_size(1024);
+            let mut decrypter =
+                AsyncSaltlickDecrypter::new_deferred(BufReader::new(encrypter), |_| {
+                    Some(secret_key)
+                });
+            let mut output = Vec::new();
+            decrypter.read_to_end(&mut output).await.unwrap();
+            assert_eq!(&random_data[..], &output[..]);
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_value_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let mut encrypter =
+            AsyncSaltlickEncrypter::new(public_key.clone(), Cursor::new(random_data));
+        let mut ciphertext = Vec::new();
+        encrypter.read_to_end(&mut ciphertext).await.unwrap();
+
+        // Inject a single bad byte near the end of the stream
+        let index = ciphertext.len() - 5;
+        ciphertext[index] = ciphertext[index].wrapping_add(1);
+
+        let mut decrypter =
+            AsyncSaltlickDecrypter::new(public_key, secret_key, Cursor::new(ciphertext));
+        let mut output = Vec::new();
+        assert!(decrypter.read_to_end(&mut output).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn incomplete_stream_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let mut encrypter =
+            AsyncSaltlickEncrypter::new(public_key.clone(), Cursor::new(random_data));
+        let mut ciphertext = Vec::new();
+        encrypter.read_to_end(&mut ciphertext).await.unwrap();
+
+        // Remove a few bytes from the end
+        ciphertext.resize(ciphertext.len() - 5, 0);
+
+        let mut decrypter =
+            AsyncSaltlickDecrypter::new(public_key, secret_key, Cursor::new(ciphertext));
+        let mut output = Vec::new();
+        assert!(decrypter.read_to_end(&mut output).await.is_err());
+    }
+
+    #[test]
+    fn into_inner_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let encrypter =
+            AsyncSaltlickEncrypter::new(public_key.clone(), Cursor::new(&random_data[..]));
+        let decrypter = AsyncSaltlickDecrypter::new(public_key, secret_key, encrypter);
+        let encrypter = decrypter.into_inner();
+        let recovered_data = encrypter.into_inner().into_inner();
+        assert_eq!(&random_data[..], recovered_data,);
+    }
+}

--- a/src/async_/stream.rs
+++ b/src/async_/stream.rs
@@ -1,0 +1,349 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Wrapper types over [`Stream`] objects.
+//!
+//! [`Stream`]: https://docs.rs/futures/0.3/futures/stream/trait.Stream.html
+
+use crate::{
+    crypter::{Decrypter, Encrypter},
+    error::SaltlickError,
+    key::{PublicKey, SecretKey},
+};
+use bytes::Bytes;
+use futures::{
+    ready,
+    stream::{Fuse, Stream, StreamExt},
+};
+use pin_project_lite::pin_project;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pin_project! {
+    /// Wraps a stream of bytes and returns a decrypted stream of bytes.
+    ///
+    /// Wraps a stream of bytes and decrypts any received data with the
+    /// provided secret key.  The public key is also checked to make sure this
+    /// encrypted data is for the public/secret key pair provided.
+    ///
+    /// The underlying stream must reach its end (i.e. return `None`) in order
+    /// to complete decryption successfully, as the libsodium crypto relies on
+    /// an end-of-stream tag to provide guarantees of completeness.
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct SaltlickDecrypterStream<S> {
+        decrypter: Decrypter,
+        #[pin]
+        inner: Fuse<S>,
+    }
+}
+
+impl<S, E> SaltlickDecrypterStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>> + 'static,
+{
+    /// Create a new decryption layer over `stream` using `secret_key` and `public_key`.
+    pub fn new(
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        stream: S,
+    ) -> SaltlickDecrypterStream<S> {
+        SaltlickDecrypterStream {
+            decrypter: Decrypter::new(public_key, secret_key),
+            inner: stream.fuse(),
+        }
+    }
+
+    /// Create a new decryption layer over `stream`, using `lookup_fn` to match
+    /// the stream's `public_key` to its `secret_key`.
+    pub fn new_deferred<F>(stream: S, lookup_fn: F) -> SaltlickDecrypterStream<S>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        SaltlickDecrypterStream {
+            decrypter: Decrypter::new_deferred(lookup_fn),
+            inner: stream.fuse(),
+        }
+    }
+
+    /// Stop reading/decrypting immediately and return the underlying reader.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
+    }
+}
+
+impl<S, E> Stream for SaltlickDecrypterStream<S>
+where
+    E: Into<io::Error> + 'static,
+    S: Stream<Item = Result<Bytes, E>> + 'static,
+{
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<io::Result<Bytes>>> {
+        let mut this = self.project();
+        loop {
+            let result = match ready!(this.inner.as_mut().poll_next(cx)) {
+                Some(Ok(input)) => {
+                    let decrypted = this.decrypter.update_to_vec(&input[..])?;
+                    if !decrypted.is_empty() {
+                        Some(Ok(Bytes::from(decrypted)))
+                    } else {
+                        continue;
+                    }
+                }
+                Some(Err(e)) => Some(Err(e.into())),
+                None if !this.decrypter.is_finalized() => {
+                    Some(Err(SaltlickError::Incomplete.into()))
+                }
+                None => None,
+            };
+            return result.into();
+        }
+    }
+}
+
+pin_project! {
+    /// Wraps a stream of bytes and returns an encrypted stream of bytes.
+    ///
+    /// Wraps a stream of bytes and encrypts any received data with the
+    /// provided public key.
+    ///
+    /// The underlying stream must reach its end (i.e. return `None`) in order
+    /// to complete encryption successfully, as the libsodium crypto relies on
+    /// an end-of-stream tag to provide guarantees of completeness.
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct SaltlickEncrypterStream<S> {
+        encrypter: Encrypter,
+        #[pin]
+        inner: Fuse<S>,
+    }
+}
+
+impl<S, E> SaltlickEncrypterStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>> + 'static,
+{
+    /// Create a new encryption layer over `stream` using `public_key`.
+    pub fn new(public_key: PublicKey, stream: S) -> SaltlickEncrypterStream<S> {
+        SaltlickEncrypterStream {
+            encrypter: Encrypter::new(public_key),
+            inner: stream.fuse(),
+        }
+    }
+
+    /// Set the block size for the underlying encrypter.
+    pub fn set_block_size(&mut self, block_size: usize) {
+        self.encrypter.set_block_size(block_size);
+    }
+
+    /// Stop reading/encrypting immediately and return the underlying reader.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
+    }
+}
+
+impl<S, E> Stream for SaltlickEncrypterStream<S>
+where
+    E: Into<io::Error> + 'static,
+    S: Stream<Item = Result<Bytes, E>> + 'static,
+{
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<io::Result<Bytes>>> {
+        let mut this = self.project();
+        loop {
+            let result = match ready!(this.inner.as_mut().poll_next(cx)) {
+                Some(Ok(input)) => {
+                    let encrypted = this.encrypter.update_to_vec(&input[..], false)?;
+                    if !encrypted.is_empty() {
+                        Some(Ok(Bytes::from(encrypted)))
+                    } else {
+                        continue;
+                    }
+                }
+                Some(Err(e)) => Some(Err(e.into())),
+                None if !this.encrypter.is_finalized() => {
+                    let encrypted = this.encrypter.update_to_vec(&[], true)?;
+                    Some(Ok(Bytes::from(encrypted)))
+                }
+                None => None,
+            };
+            return result.into();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SaltlickDecrypterStream, SaltlickEncrypterStream};
+    use crate::key::gen_keypair;
+    use bytes::{Bytes, BytesMut};
+    use futures::Stream;
+    use rand::{Rng, RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+    use std::{cmp, io};
+    use tokio::stream::{self, StreamExt};
+
+    fn random_bytes(seed: u64, size: usize) -> Box<[u8]> {
+        let mut rng = XorShiftRng::seed_from_u64(seed);
+        let mut bytes = vec![0u8; size];
+        rng.fill_bytes(&mut bytes);
+        bytes.into_boxed_slice()
+    }
+
+    #[tokio::test]
+    async fn round_trip_test() {
+        for size in &[
+            1,
+            10 * 1024,
+            32 * 1024,
+            100 * 1024,
+            200 * 1024,
+            10 * 1024 * 1024,
+        ] {
+            let random_data = random_bytes(0, *size);
+            let (public_key, secret_key) = gen_keypair();
+            let input_stream =
+                stream::once(Ok::<_, io::Error>(Bytes::copy_from_slice(&random_data[..])));
+            let mut encrypter = SaltlickEncrypterStream::new(public_key.clone(), input_stream);
+            encrypter.set_block_size(16 * 1024);
+            let decrypter = SaltlickDecrypterStream::new_deferred(encrypter, |_| Some(secret_key));
+
+            let output: Bytes = decrypter
+                .collect::<Result<Bytes, io::Error>>()
+                .await
+                .unwrap();
+            assert_eq!(&random_data[..], &output[..]);
+        }
+    }
+
+    fn random_chunks(seed: u64, data: &[u8]) -> impl Stream<Item = io::Result<Bytes>> {
+        let mut bytes = Bytes::copy_from_slice(data);
+        let mut rng = XorShiftRng::seed_from_u64(seed);
+        async_stream::stream! {
+            loop {
+                if bytes.is_empty() {
+                    break;
+                }
+                let n = rng.gen_range(1, 1024);
+                let take = cmp::min(bytes.len(), n);
+                yield Ok(bytes.split_to(take));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_write_test() {
+        for size in &[
+            1,
+            10 * 1024,
+            32 * 1024,
+            100 * 1024,
+            200 * 1024,
+            10 * 1024 * 1024,
+        ] {
+            let random_data = random_bytes(0, *size);
+            let (public_key, secret_key) = gen_keypair();
+
+            // Take increasing chunks so we're varying chunk size.
+            let input_stream = random_chunks(0, &random_data[..]);
+            let encrypter = SaltlickEncrypterStream::new(public_key.clone(), input_stream);
+            let decrypter = SaltlickDecrypterStream::new(public_key, secret_key, encrypter);
+
+            let output: Bytes = decrypter
+                .collect::<Result<Bytes, io::Error>>()
+                .await
+                .unwrap();
+            assert_eq!(&random_data[..], &output[..]);
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_value_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let input_stream =
+            stream::once(Ok::<_, io::Error>(Bytes::copy_from_slice(&random_data[..])));
+        let encrypter = SaltlickEncrypterStream::new(public_key.clone(), input_stream);
+        let mut ciphertext = encrypter
+            .collect::<Result<BytesMut, io::Error>>()
+            .await
+            .unwrap();
+
+        // Inject a single bad byte near the end of the stream
+        let index = ciphertext.len() - 5;
+        ciphertext[index] = ciphertext[index].wrapping_add(1);
+
+        let cipher_stream = stream::once(Ok::<_, io::Error>(ciphertext.freeze()));
+        let decrypter = SaltlickDecrypterStream::new(public_key, secret_key, cipher_stream);
+        decrypter
+            .collect::<Result<Bytes, io::Error>>()
+            .await
+            .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn incomplete_stream_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let input_stream =
+            stream::once(Ok::<_, io::Error>(Bytes::copy_from_slice(&random_data[..])));
+        let encrypter = SaltlickEncrypterStream::new(public_key.clone(), input_stream);
+        let mut ciphertext = encrypter
+            .collect::<Result<BytesMut, io::Error>>()
+            .await
+            .unwrap();
+
+        // Remove a few bytes from the end
+        ciphertext.truncate(ciphertext.len() - 5);
+
+        let cipher_stream = stream::once(Ok::<_, io::Error>(ciphertext.freeze()));
+        let decrypter = SaltlickDecrypterStream::new(public_key, secret_key.clone(), cipher_stream);
+        decrypter
+            .collect::<Result<Bytes, io::Error>>()
+            .await
+            .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn underlying_stream_error_test() {
+        let (public_key, secret_key) = gen_keypair();
+        let input_stream = stream::once(Err::<Bytes, _>(io::Error::from(io::ErrorKind::Other)));
+        let encrypter = SaltlickEncrypterStream::new(public_key.clone(), input_stream);
+        let decrypter = SaltlickDecrypterStream::new(public_key, secret_key, encrypter);
+
+        let error = decrypter
+            .collect::<Result<Bytes, io::Error>>()
+            .await
+            .unwrap_err();
+        assert_eq!(io::ErrorKind::Other, error.kind());
+    }
+
+    #[tokio::test]
+    async fn into_inner_test() {
+        // Making sure that passing a stream through the encrypter/decrypter
+        // and not performing any operations still returns the untouched input
+        // stream.
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let input_stream =
+            stream::once(Ok::<_, io::Error>(Bytes::copy_from_slice(&random_data[..])));
+        let encrypter = SaltlickEncrypterStream::new(public_key.clone(), input_stream);
+        let decrypter = SaltlickDecrypterStream::new(public_key, secret_key, encrypter);
+        let encrypter = decrypter.into_inner();
+        let mut input_stream = encrypter.into_inner();
+        assert_eq!(
+            Bytes::copy_from_slice(&random_data[..]),
+            input_stream.next().await.unwrap().unwrap()
+        );
+    }
+}

--- a/src/async_/write.rs
+++ b/src/async_/write.rs
@@ -1,0 +1,315 @@
+// Copyright (c) 2020, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Wrapper types over [`AsyncWrite`] objects.
+//!
+//! [`AsyncWrite`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncWrite.html
+
+use super::commonio::{self, AsyncBuffer};
+use crate::{
+    crypter::{Decrypter, Encrypter, DEFAULT_BLOCK_SIZE, MIN_BLOCK_SIZE},
+    key::{PublicKey, SecretKey},
+};
+use pin_project_lite::pin_project;
+use std::{
+    cmp, io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::AsyncWrite;
+
+pin_project! {
+    /// Wraps an underlying writer with decryption using the saltlick format.
+    ///
+    /// Wraps a writer that implements [`AsyncWrite`] and returns a type that
+    /// also implements [`AsyncWrite`]. Any data written to the returned type
+    /// will be decrypted with the provided secret key and written to the
+    /// underlying writer.  The public key is also checked to make sure this
+    /// encrypted data is for the public/secret key pair provided.
+    ///
+    /// Any data written after the encrypted stream is complete will be
+    /// discarded.
+    ///
+    /// # Note
+    ///
+    /// If writing fails during the stream, the entire stream must be discarded
+    /// and started over, as the underlying crypto prevents restarting.
+    ///
+    /// [`AsyncWrite`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncWrite.html
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct AsyncSaltlickDecrypter<W> {
+        buffer: AsyncBuffer,
+        decrypter: Decrypter,
+        #[pin]
+        inner: W,
+    }
+}
+
+impl<W: AsyncWrite> AsyncSaltlickDecrypter<W> {
+    /// Create a new decryption layer over `writer` using `secret_key` and `public_key`.
+    pub fn new(
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        writer: W,
+    ) -> AsyncSaltlickDecrypter<W> {
+        Self::with_capacity(DEFAULT_BLOCK_SIZE, public_key, secret_key, writer)
+    }
+
+    /// Create a new decryption layer over `writer`, using `lookup_fn` to match
+    /// the stream's `public_key` to its `secret_key`.
+    pub fn new_deferred<F>(writer: W, lookup_fn: F) -> AsyncSaltlickDecrypter<W>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        Self::deferred_with_capacity(DEFAULT_BLOCK_SIZE, writer, lookup_fn)
+    }
+
+    /// Create a new decryption layer over `writer` using `secret_key` and
+    /// `public_key` with the provided buffer `capacity`.
+    pub fn with_capacity(
+        capacity: usize,
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        writer: W,
+    ) -> AsyncSaltlickDecrypter<W> {
+        let capacity = cmp::max(capacity, MIN_BLOCK_SIZE);
+        AsyncSaltlickDecrypter {
+            buffer: AsyncBuffer::new(capacity),
+            decrypter: Decrypter::new(public_key, secret_key),
+            inner: writer,
+        }
+    }
+
+    /// Create a new decryption layer over `writer`, using `lookup_fn` to match
+    /// the stream's `public_key` to its `secret_key` with the provided buffer
+    /// capacity.
+    pub fn deferred_with_capacity<F>(
+        capacity: usize,
+        writer: W,
+        lookup_fn: F,
+    ) -> AsyncSaltlickDecrypter<W>
+    where
+        F: FnOnce(&PublicKey) -> Option<SecretKey> + 'static,
+    {
+        let capacity = cmp::max(capacity, MIN_BLOCK_SIZE);
+        AsyncSaltlickDecrypter {
+            buffer: AsyncBuffer::new(capacity),
+            decrypter: Decrypter::new_deferred(lookup_fn),
+            inner: writer,
+        }
+    }
+
+    /// Stop writing/decrypting immediately and return the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for AsyncSaltlickDecrypter<W> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, input: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.project();
+        commonio::poll_write(this.inner, cx, this.decrypter, this.buffer, input)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let this = self.project();
+        commonio::poll_flush(this.inner, cx, this.buffer)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let this = self.project();
+        commonio::poll_shutdown(this.inner, cx, this.decrypter, this.buffer)
+    }
+}
+
+pin_project! {
+    /// Wraps an underlying writer with encryption using the saltlick format.
+    ///
+    /// Wraps a writer that implements [`AsyncWrite`] and returns a type that
+    /// also implements [`AsyncWrite`].  Any data written to the returned type
+    /// will be encrypted with the provided public key and written to the
+    /// underlying writer.
+    ///
+    /// # Note
+    ///
+    /// If writing fails during the stream, the entire stream must be discarded
+    /// and started over, as the underlying crypto prevents restarting.
+    ///
+    /// If polling manually, the `poll_shutdown` function must be called. If
+    /// it is not called, the stream will not be finalized and decryption will
+    /// fail with an [`Incomplete` error](../enum.SaltlickError.html).
+    ///
+    /// [`AsyncWrite`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncWrite.html
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-async")))]
+    #[derive(Debug)]
+    pub struct AsyncSaltlickEncrypter<W> {
+        buffer: AsyncBuffer,
+        encrypter: Encrypter,
+        #[pin]
+        inner: W,
+    }
+}
+
+impl<W: AsyncWrite> AsyncSaltlickEncrypter<W> {
+    /// Create a new encryption layer over `writer` using `public_key`.
+    pub fn new(public_key: PublicKey, writer: W) -> AsyncSaltlickEncrypter<W> {
+        AsyncSaltlickEncrypter::with_capacity(DEFAULT_BLOCK_SIZE, public_key, writer)
+    }
+
+    /// Create a new encryption layer over `writer` using `public_key` with the
+    /// provided buffer `capacity`.
+    pub fn with_capacity(
+        capacity: usize,
+        public_key: PublicKey,
+        writer: W,
+    ) -> AsyncSaltlickEncrypter<W> {
+        let capacity = cmp::max(capacity, MIN_BLOCK_SIZE);
+        AsyncSaltlickEncrypter {
+            buffer: AsyncBuffer::new(capacity),
+            encrypter: Encrypter::new(public_key),
+            inner: writer,
+        }
+    }
+
+    /// Set the block size for the underlying encrypter.
+    pub fn set_block_size(&mut self, block_size: usize) {
+        self.encrypter.set_block_size(block_size);
+    }
+
+    /// Stop writing/encrypting immediately and return the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for AsyncSaltlickEncrypter<W> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, input: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.project();
+        commonio::poll_write(this.inner, cx, this.encrypter, this.buffer, input)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let this = self.project();
+        commonio::poll_flush(this.inner, cx, this.buffer)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let this = self.project();
+        commonio::poll_shutdown(this.inner, cx, this.encrypter, this.buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncSaltlickDecrypter, AsyncSaltlickEncrypter};
+    use crate::key::gen_keypair;
+    use rand::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+    use std::{cmp, iter};
+    use tokio::io::AsyncWriteExt;
+
+    fn random_bytes(seed: u64, size: usize) -> Box<[u8]> {
+        let mut rng = XorShiftRng::seed_from_u64(seed);
+        let mut bytes = vec![0u8; size];
+        rng.fill_bytes(&mut bytes);
+        bytes.into_boxed_slice()
+    }
+
+    #[tokio::test]
+    async fn single_write_test() {
+        for size in &[
+            1,
+            10 * 1024,
+            32 * 1024,
+            100 * 1024,
+            200 * 1024,
+            10 * 1024 * 1024,
+        ] {
+            let random_data = random_bytes(0, *size);
+            let (public_key, secret_key) = gen_keypair();
+            let decrypter = AsyncSaltlickDecrypter::new_deferred(Vec::new(), |_| Some(secret_key));
+            let mut encrypter = AsyncSaltlickEncrypter::new(public_key.clone(), decrypter);
+            encrypter.write_all(&random_data[..]).await.unwrap();
+            encrypter.flush().await.unwrap();
+            encrypter.shutdown().await.unwrap();
+            let output = encrypter.into_inner().into_inner();
+            assert_eq!(&random_data[..], &output[..]);
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_write_test() {
+        for size in &[
+            1,
+            10 * 1024,
+            32 * 1024,
+            100 * 1024,
+            200 * 1024,
+            10 * 1024 * 1024,
+        ] {
+            let random_data = random_bytes(0, *size);
+            let (public_key, secret_key) = gen_keypair();
+            let decrypter = AsyncSaltlickDecrypter::new(public_key.clone(), secret_key, Vec::new());
+            let mut encrypter = AsyncSaltlickEncrypter::new(public_key, decrypter);
+            encrypter.set_block_size(16 * 1024);
+
+            // Take increasing chunks so we're varying chunk size.
+            let mut written = 0;
+            for take in iter::successors(Some(1usize), |n| Some(n + 7)) {
+                let end = cmp::min(written + take, *size);
+                encrypter
+                    .write_all(&random_data[written..end])
+                    .await
+                    .unwrap();
+                written += take;
+                if written >= *size {
+                    break;
+                }
+            }
+
+            encrypter.shutdown().await.unwrap();
+            let output = encrypter.into_inner().into_inner();
+            assert_eq!(&random_data[..], &output[..]);
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_value_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let mut encrypter = AsyncSaltlickEncrypter::new(public_key.clone(), Vec::new());
+        encrypter.write_all(&random_data[..]).await.unwrap();
+        encrypter.shutdown().await.unwrap();
+        let mut ciphertext = encrypter.into_inner();
+
+        // Inject a single bad byte near the end of the stream
+        let index = ciphertext.len() - 5;
+        ciphertext[index] = ciphertext[index].wrapping_add(1);
+
+        let mut decrypter = AsyncSaltlickDecrypter::new(public_key, secret_key, Vec::new());
+        assert!(decrypter.write_all(&ciphertext[..]).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn incomplete_stream_test() {
+        let random_data = random_bytes(0, 100 * 1024);
+        let (public_key, secret_key) = gen_keypair();
+        let mut encrypter = AsyncSaltlickEncrypter::new(public_key.clone(), Vec::new());
+        encrypter.write_all(&random_data[..]).await.unwrap();
+        encrypter.shutdown().await.unwrap();
+        let mut ciphertext = encrypter.into_inner();
+
+        // Remove a few bytes from the end
+        ciphertext.resize(ciphertext.len() - 5, 0);
+
+        let mut decrypter = AsyncSaltlickDecrypter::new(public_key, secret_key, Vec::new());
+        decrypter.write_all(&ciphertext[..]).await.unwrap();
+        assert!(decrypter.shutdown().await.is_err());
+    }
+}

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -17,6 +17,9 @@ use crate::{
 };
 use std::io::{self, BufRead, Read};
 
+#[cfg(feature = "io-async")]
+pub use crate::async_::bufread::*;
+
 /// Wraps an underlying reader with decryption using the saltlick format.
 ///
 /// Wraps a reader that implements [`BufRead`] and returns a type that also

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,18 @@
 //! openssl pkey -in secret.pem -pubout > public.pem
 //! ```
 
+// Enables the nightly-only doc_cfg feature when the `docsrs` attribute is
+// preset. We only set this attribute during builds on docs.rs, configured
+// using Cargo.toml package metadata.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod bufread;
 pub mod crypter;
 pub mod read;
 pub mod write;
+
+#[cfg(feature = "io-async")]
+pub(crate) mod async_;
 
 mod commonio;
 mod error;
@@ -98,3 +106,6 @@ pub use self::{
     key::{gen_keypair, PublicKey, SecretKey, PUBLICKEYBYTES, SECRETKEYBYTES},
     version::Version,
 };
+
+#[cfg(feature = "io-async")]
+pub use self::async_::stream;

--- a/src/read.rs
+++ b/src/read.rs
@@ -20,6 +20,9 @@ use std::{
     io::{self, BufReader, Read},
 };
 
+#[cfg(feature = "io-async")]
+pub use crate::async_::read::*;
+
 /// Wraps an underlying reader with decryption using the saltlick format.
 ///
 /// Wraps a reader that implements [`Read`] and returns a type that also

--- a/src/write.rs
+++ b/src/write.rs
@@ -20,6 +20,9 @@ use std::{
     io::{self, Write},
 };
 
+#[cfg(feature = "io-async")]
+pub use crate::async_::write::*;
+
 /// Wraps an underlying writer with decryption using the saltlick format.
 ///
 /// Wraps a writer that implements [`Write`] and returns a type that also


### PR DESCRIPTION
The main event!

This adds asynchronous APIs for saltlick based on Tokio 0.2 / Futures 0.3. In this case, "async APIs" means implementations of `AsyncRead`, `AsyncBufRead`, `AsyncWrite`, and `Stream` for both encrypting and decrypting. There's an argument to be made for adding a `Sink` implementation as well, but I'm going to leave that for a future enhancement.

One extra thing to note: the pattern `#![cfg_attr(docsrs, feature(doc_cfg))]` combined with the `[package.metadata.docs.rs]` section in the `Cargo.toml` allows us to generate labels on features that are behind feature flags for docs.rs documentation. You can see what this looks like in the [`tokio docs`](https://docs.rs/tokio/) - it will add a tag `feature="io-async"` to types requiring that feature. This can't be enabled generically because the `cfg_doc` feature is not stable. If you want to try this out yourself you can run `RUSTDOCFLAGS='--cfg docsrs' cargo +nightly rustdoc --all-features`