### PR TITLE
stream: Fix empty buffer returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [master] - Unreleased
+- Fix issue where `AsyncDecrypterStream` would return empty buffers while
+  processing streams.
 
 ## [0.4.0] - 2020-07-13
 ### Added

--- a/src/async_/stream.rs
+++ b/src/async_/stream.rs
@@ -99,6 +99,9 @@ impl SaltlickDecrypterStream {
             while let Some(value) = stream.next().await {
                 let value = value?;
                 let res = decrypter.update_to_vec(&value[..]).await?;
+                if res.is_empty() {
+                    continue;
+                }
                 yield Bytes::from(res);
             }
             if !decrypter.is_finalized() {


### PR DESCRIPTION
Previously an issue was encountered with the decrypter
stream where empty buffers would be returned by the
stream while making progress. The fix wasn't incorporated
when the decrypter was converted to async-streams. This
change adds it back.

Signed-off-by: Trenton Andres <trenton.andres@gmail.com>