### PR TITLE
chore: add examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,19 @@ tempdir = "0.3"
 
 [dev-dependencies.tokio]
 version = "0.2"
-features = ["io-util", "macros", "rt-threaded", "stream"]
+features = ["fs", "io-util", "macros", "rt-threaded", "stream"]
 
 [features]
 default = []
 io-async = ["async-stream", "futures", "pin-project-lite", "tokio"]
 proptest-tests = []
+
+[[example]]
+name = "simple"
+
+[[example]]
+name = "simple_async"
+required-features = ["io-async"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,25 @@
+use saltlick::{read::SaltlickDecrypter, write::SaltlickEncrypter};
+use std::{
+    error::Error,
+    io::{Cursor, Read, Write},
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Generate a new public/secret keypair
+    let (public, secret) = saltlick::gen_keypair();
+
+    // Writing data to a stream
+    let writer = Vec::new();
+    let mut stream = SaltlickEncrypter::new(public.clone(), writer);
+    stream.write_all(b"I have a secret for you")?;
+    let ciphertext = stream.finalize()?;
+
+    // Reading data back from stream
+    let reader = Cursor::new(ciphertext);
+    let mut stream = SaltlickDecrypter::new(public, secret, reader);
+    let mut output = String::new();
+    stream.read_to_string(&mut output)?;
+    assert_eq!("I have a secret for you", output);
+
+    Ok(())
+}

--- a/examples/simple_async.rs
+++ b/examples/simple_async.rs
@@ -1,0 +1,33 @@
+use saltlick::{read::AsyncSaltlickDecrypter, write::AsyncSaltlickEncrypter};
+use std::error::Error;
+use tempdir::TempDir;
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Generate a new public/secret keypair
+    let (public, secret) = saltlick::gen_keypair();
+
+    let tmp_dir = TempDir::new("saltlick-async")?;
+    let file_path = tmp_dir.path().join("secretfile.enc");
+
+    // Writing data to a file asynchronously
+    let file_writer = File::create(&file_path).await?;
+    let mut stream = AsyncSaltlickEncrypter::new(public.clone(), file_writer);
+    stream.write_all(b"I have a secret for you").await?;
+
+    // Ensure all data is flushed to filesystem
+    stream.shutdown().await?;
+
+    // Reading data back from file asynchronously
+    let file_reader = File::open(&file_path).await?;
+    let mut stream = AsyncSaltlickDecrypter::new(public.clone(), secret.clone(), file_reader);
+    let mut output = String::new();
+    let _ = stream.read_to_string(&mut output).await?;
+    assert_eq!("I have a secret for you", output);
+
+    Ok(())
+}


### PR DESCRIPTION
Adds feature `fs` to `dev-dependencies.tokio` for the async I/O example.